### PR TITLE
Remove eval from get

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -777,6 +777,22 @@
         "babel-plugin-jest-hoist": "^24.6.0"
       }
     },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -1216,6 +1232,11 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
+    },
+    "core-js": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -2282,7 +2303,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dev": true,
       "requires": {
         "locate-path": "^3.0.0"
       }
@@ -2363,8 +2383,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2385,14 +2404,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2407,20 +2424,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2537,8 +2551,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2550,7 +2563,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2565,7 +2577,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2573,14 +2584,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2599,7 +2608,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2680,8 +2688,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2693,7 +2700,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2779,8 +2785,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2816,7 +2821,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2836,7 +2840,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2880,14 +2883,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3696,6 +3697,8 @@
     },
     "jest": {
       "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-24.8.0.tgz",
+      "integrity": "sha512-o0HM90RKFRNWmAWvlyV8i5jGZ97pFwkeVoGvPW1EtLTgJc2+jcuqcbbqcSZLE/3f2S5pt0y2ZBETuhpWNl1Reg==",
       "dev": true,
       "requires": {
         "import-local": "^2.0.0",
@@ -4435,7 +4438,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dev": true,
       "requires": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
@@ -4643,8 +4645,7 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -5018,7 +5019,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
       "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-      "dev": true,
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -5027,7 +5027,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dev": true,
       "requires": {
         "p-limit": "^2.0.0"
       }
@@ -5047,8 +5046,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "parse-json": {
       "version": "4.0.0",
@@ -5075,8 +5073,7 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -5254,6 +5251,30 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
+    },
+    "prettier-standard": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/prettier-standard/-/prettier-standard-9.1.1.tgz",
+      "integrity": "sha512-d23Hbdf7tIJ5qeEPEv+7B9cGGczJBOyq188kiKGPk/lvlrM3J8umWC8rR9LIbWmuMzbl5iDSL7kG1/wZgh3EYg==",
+      "requires": {
+        "find-up": "^3.0.0",
+        "get-stdin": "^6.0.0",
+        "minimist": "^1.2.0",
+        "prettierx": "0.3.0",
+        "stream-mock": "1.2.0"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
+        }
+      }
+    },
+    "prettierx": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/prettierx/-/prettierx-0.3.0.tgz",
+      "integrity": "sha512-cMtPQ1+mhWsMPAJycwUqVYQBL30TrVJnVz8K888WN67mpXMHAHGY53jLgFR2Pr3v3YE8Rz9kxZCB7S7vAfz1iA=="
     },
     "pretty-format": {
       "version": "24.8.0",
@@ -6068,6 +6089,14 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
+    },
+    "stream-mock": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stream-mock/-/stream-mock-1.2.0.tgz",
+      "integrity": "sha1-9otVI8Dhz+YZ6gnX0QlykPQFuWo=",
+      "requires": {
+        "babel-runtime": "^6.26.0"
+      }
     },
     "string-argv": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "husky": "^2.4.0",
     "jest": "^24.8.0",
     "lint-staged": "^8.2.0",
-    "standard": "^12.0.1"
+    "standard": "^12.0.1",
+    "prettier-standard": "^9.1.1"
   }
 }

--- a/src/get.js
+++ b/src/get.js
@@ -1,15 +1,15 @@
-const get = attr => obj => {
-  if (!obj) return
+const get = (attr) => (obj) => {
+  if (!obj) return;
 
-  if (!typeof attr === 'string') return
+  if (typeof attr !== 'string') return;
 
   if (attr.match(/\./)) {
-    const [first, ...rest] = attr.split('.')
+    const [first, ...rest] = attr.split('.');
 
-    return get(rest.join(''))(obj[first])
+    return get(rest.join(''))(obj[first]);
   }
 
-  return obj[attr]
-}
+  return obj[attr];
+};
 
-module.exports = get
+module.exports = get;

--- a/src/get.js
+++ b/src/get.js
@@ -1,15 +1,15 @@
 const get = (attr) => (obj) => {
-  if (!obj) return;
+  if (!obj) return
 
-  if (typeof attr !== 'string') return;
+  if (typeof attr !== 'string') return
 
   if (attr.match(/\./)) {
-    const [first, ...rest] = attr.split('.');
+    const [first, ...rest] = attr.split('.')
 
-    return get(rest.join(''))(obj[first]);
+    return get(rest.join(''))(obj[first])
   }
 
-  return obj[attr];
-};
+  return obj[attr]
+}
 
-module.exports = get;
+module.exports = get

--- a/src/get.js
+++ b/src/get.js
@@ -1,12 +1,16 @@
-const get = (attr) => (obj) => {
-  if (!obj) return
+const get = attr => obj => {
+  if (!obj || !attr) return
 
-  if (typeof attr !== 'string') return
+  if (Object.prototype.toString.call(obj) !== '[object Object]') return
 
-  if (attr.match(/\./)) {
-    const [first, ...rest] = attr.split('.')
+  if (Object.prototype.toString.call(attr) !== '[object String]') return
 
-    return get(rest.join(''))(obj[first])
+  const nested = attr.match(/\./)
+  if (nested && nested.index !== 0) {
+    const first = attr.substring(0, nested.index)
+    const rest = attr.substring(nested.index + 1)
+
+    return get(rest)(obj[first])
   }
 
   return obj[attr]

--- a/src/get.js
+++ b/src/get.js
@@ -1,6 +1,15 @@
 const get = attr => obj => {
-  const value = eval(`obj.${attr}`)
-  return value ? value : null
+  if (!obj) return
+
+  if (!typeof attr === 'string') return
+
+  if (attr.match(/\./)) {
+    const [first, ...rest] = attr.split('.')
+
+    return get(rest.join(''))(obj[first])
+  }
+
+  return obj[attr]
 }
 
 module.exports = get

--- a/test/get.test.js
+++ b/test/get.test.js
@@ -1,29 +1,42 @@
-const { get } = require('../src')
+const { get } = require('../src');
 
 describe('get', function() {
   it('should return element of a given object', () => {
-    const obj = { abc: 123 }
-    expect(get('abc')(obj)).toEqual(123)
-  })
+    const obj = { abc: 123 };
+    expect(get('abc')(obj)).toEqual(123);
+  });
 
   it('should return element inside a deep object', () => {
-    const deepObj = { abc: { def: 123 } }
-    expect(get('abc.def')(deepObj)).toEqual(123)
-  })
-  
+    const deepObj = { abc: { def: 123 } };
+    expect(get('abc.def')(deepObj)).toEqual(123);
+  });
+
   it('should return undefined for nonexistent keys', () => {
-    const obj = { abc: 123 }
+    const obj = { abc: 123 };
     expect(get('def')(obj)).toBeUndefined();
-  })
+  });
 
   it('should return undefined for falsy objects', () => {
     expect(get('key')(null)).toBeUndefined();
     expect(get('key')(undefined)).toBeUndefined();
-  })
+  });
 
   it('should return undefined if it is not object', () => {
     expect(get('key')([])).toBeUndefined();
     expect(get('key')(() => {})).toBeUndefined();
     expect(get('key')('{ key: 1 }')).toBeUndefined();
-  })
-})
+  });
+
+  it('should return undefined for falsy keys', () => {
+    const obj = { abc: 123 };
+    expect(get(null)(obj)).toBeUndefined();
+    expect(get(undefined)(obj)).toBeUndefined();
+  });
+
+  it('should return undefined if key is not string', () => {
+    const obj = { abc: 123 };
+    expect(get([])(obj)).toBeUndefined();
+    expect(get(() => {})(obj)).toBeUndefined();
+    expect(get(100)(obj)).toBeUndefined();
+  });
+});

--- a/test/get.test.js
+++ b/test/get.test.js
@@ -1,42 +1,42 @@
-const { get } = require('../src');
+const { get } = require('../src')
 
-describe('get', function() {
+describe('get', function () {
   it('should return element of a given object', () => {
-    const obj = { abc: 123 };
-    expect(get('abc')(obj)).toEqual(123);
-  });
+    const obj = { abc: 123 }
+    expect(get('abc')(obj)).toEqual(123)
+  })
 
   it('should return element inside a deep object', () => {
-    const deepObj = { abc: { def: 123 } };
-    expect(get('abc.def')(deepObj)).toEqual(123);
-  });
+    const deepObj = { abc: { def: 123 } }
+    expect(get('abc.def')(deepObj)).toEqual(123)
+  })
 
   it('should return undefined for nonexistent keys', () => {
-    const obj = { abc: 123 };
-    expect(get('def')(obj)).toBeUndefined();
-  });
+    const obj = { abc: 123 }
+    expect(get('def')(obj)).toBeUndefined()
+  })
 
   it('should return undefined for falsy objects', () => {
-    expect(get('key')(null)).toBeUndefined();
-    expect(get('key')(undefined)).toBeUndefined();
-  });
+    expect(get('key')(null)).toBeUndefined()
+    expect(get('key')(undefined)).toBeUndefined()
+  })
 
   it('should return undefined if it is not object', () => {
-    expect(get('key')([])).toBeUndefined();
-    expect(get('key')(() => {})).toBeUndefined();
-    expect(get('key')('{ key: 1 }')).toBeUndefined();
-  });
+    expect(get('key')([])).toBeUndefined()
+    expect(get('key')(() => {})).toBeUndefined()
+    expect(get('key')('{ key: 1 }')).toBeUndefined()
+  })
 
   it('should return undefined for falsy keys', () => {
-    const obj = { abc: 123 };
-    expect(get(null)(obj)).toBeUndefined();
-    expect(get(undefined)(obj)).toBeUndefined();
-  });
+    const obj = { abc: 123 }
+    expect(get(null)(obj)).toBeUndefined()
+    expect(get(undefined)(obj)).toBeUndefined()
+  })
 
   it('should return undefined if key is not string', () => {
-    const obj = { abc: 123 };
-    expect(get([])(obj)).toBeUndefined();
-    expect(get(() => {})(obj)).toBeUndefined();
-    expect(get(100)(obj)).toBeUndefined();
-  });
-});
+    const obj = { abc: 123 }
+    expect(get([])(obj)).toBeUndefined()
+    expect(get(() => {})(obj)).toBeUndefined()
+    expect(get(100)(obj)).toBeUndefined()
+  })
+})

--- a/test/get.test.js
+++ b/test/get.test.js
@@ -1,10 +1,29 @@
 const { get } = require('../src')
 
-test('test get function', () => {
-  const obj = { abc: 123 }
-  expect(get('abc')(obj)).toEqual(123)
-  expect(get('dec')(obj)).toEqual(null)
+describe('get', function() {
+  it('should return element of a given object', () => {
+    const obj = { abc: 123 }
+    expect(get('abc')(obj)).toEqual(123)
+  })
 
-  const deepObj = { abc: { def: 123 } }
-  expect(get('abc.def')(deepObj)).toEqual(123)
+  it('should return element inside a deep object', () => {
+    const deepObj = { abc: { def: 123 } }
+    expect(get('abc.def')(deepObj)).toEqual(123)
+  })
+  
+  it('should return undefined for nonexistent keys', () => {
+    const obj = { abc: 123 }
+    expect(get('def')(obj)).toBeUndefined();
+  })
+
+  it('should return undefined for falsy objects', () => {
+    expect(get('key')(null)).toBeUndefined();
+    expect(get('key')(undefined)).toBeUndefined();
+  })
+
+  it('should return undefined if it is not object', () => {
+    expect(get('key')([])).toBeUndefined();
+    expect(get('key')(() => {})).toBeUndefined();
+    expect(get('key')('{ key: 1 }')).toBeUndefined();
+  })
 })


### PR DESCRIPTION
**Description**

Malicious code can be executed inside `eval`. 
```
get("log('hacked!')")(console); // hacked!
```

**Proposed change**
- Return `undefined` for nonexistent keys. It seems like a standard return value for this case.
- Replace `eval`
- Write separate test cases

